### PR TITLE
Add builder mini shortcuts and focus handling

### DIFF
--- a/apps/builder/app/builder-mini/_components/HeaderBar.tsx
+++ b/apps/builder/app/builder-mini/_components/HeaderBar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect } from "react";
+import { BuilderNodeType, useBuilder } from "./builderContext";
+
+const isEditableElement = (target: EventTarget | null): boolean => {
+  if (!target || !(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  if (target.isContentEditable) {
+    return true;
+  }
+  return tagName === "input" || tagName === "textarea" || tagName === "select";
+};
+
+const toNodeType = (key: string): BuilderNodeType | null => {
+  if (key === "t") {
+    return "text";
+  }
+  if (key === "b") {
+    return "button";
+  }
+  return null;
+};
+
+const useGlobalNodeShortcuts = () => {
+  const { addNode, focusNodeNameInput } = useBuilder();
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      if (isEditableElement(event.target)) {
+        return;
+      }
+      const nodeType = toNodeType(event.key.toLowerCase());
+      if (!nodeType) {
+        return;
+      }
+      addNode(nodeType);
+      focusNodeNameInput();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [addNode, focusNodeNameInput]);
+};
+
+export const HeaderBar: React.FC = () => {
+  useGlobalNodeShortcuts();
+  return (
+    <header className="header-bar">
+      <h1>Builder Mini</h1>
+    </header>
+  );
+};

--- a/apps/builder/app/builder-mini/_components/RightPane.tsx
+++ b/apps/builder/app/builder-mini/_components/RightPane.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ChangeEventHandler, useEffect, useMemo, useRef } from "react";
+import { useBuilder } from "./builderContext";
+
+const getNodeName = (nodes: ReturnType<typeof useBuilder>["nodes"], selectedId: string | null) => {
+  if (!selectedId) {
+    return "";
+  }
+  const node = nodes.find((item) => item.id === selectedId);
+  return node?.name ?? "";
+};
+
+const useNodeNameChange = (selectedId: string | null, renameNode: (id: string, name: string) => void) => {
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    if (!selectedId) {
+      return;
+    }
+    renameNode(selectedId, event.target.value);
+  };
+  return handleChange;
+};
+
+export const RightPane: React.FC = () => {
+  const { nodes, selectedId, renameNode, attachNodeNameInput, focusNodeNameInput } = useBuilder();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const nodeName = useMemo(() => getNodeName(nodes, selectedId), [nodes, selectedId]);
+  const handleChange = useNodeNameChange(selectedId, renameNode);
+
+  useEffect(() => {
+    attachNodeNameInput(inputRef.current);
+    return () => {
+      attachNodeNameInput(null);
+    };
+  }, [attachNodeNameInput]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      return;
+    }
+    focusNodeNameInput();
+  }, [selectedId, focusNodeNameInput]);
+
+  return (
+    <aside className="right-pane">
+      <label className="node-name">
+        <span>ノード名</span>
+        <input ref={inputRef} value={nodeName} onChange={handleChange} />
+      </label>
+    </aside>
+  );
+};

--- a/apps/builder/app/builder-mini/_components/builderContext.tsx
+++ b/apps/builder/app/builder-mini/_components/builderContext.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+
+export type BuilderNodeType = "text" | "button";
+
+export interface BuilderNode {
+  readonly id: string;
+  readonly type: BuilderNodeType;
+  readonly name: string;
+}
+
+interface BuilderContextValue {
+  readonly nodes: ReadonlyArray<BuilderNode>;
+  readonly selectedId: string | null;
+  readonly addNode: (type: BuilderNodeType) => BuilderNode;
+  readonly renameNode: (id: string, name: string) => void;
+  readonly selectNode: (id: string | null) => void;
+  readonly attachNodeNameInput: (input: HTMLInputElement | null) => void;
+  readonly focusNodeNameInput: () => void;
+}
+
+const BuilderContext = createContext<BuilderContextValue | null>(null);
+
+const buildNodeName = (type: BuilderNodeType, index: number) => {
+  const label = type === "text" ? "Text" : "Button";
+  return `${label} ${index}`;
+};
+
+const useNodesState = () => {
+  const [nodes, setNodes] = useState<ReadonlyArray<BuilderNode>>([]);
+  const renameNode = useCallback((id: string, name: string) => {
+    setNodes((current) => current.map((node) => (node.id === id ? { ...node, name } : node)));
+  }, []);
+  return { nodes, setNodes, renameNode } as const;
+};
+
+const useSelectionState = () => {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selectNode = useCallback((id: string | null) => {
+    setSelectedId(id);
+  }, []);
+  return { selectedId, selectNode } as const;
+};
+
+const useNodeNameInputHandle = () => {
+  const nodeNameInputRef = useRef<HTMLInputElement | null>(null);
+  const attachNodeNameInput = useCallback((input: HTMLInputElement | null) => {
+    nodeNameInputRef.current = input;
+  }, []);
+  const focusNodeNameInput = useCallback(() => {
+    const input = nodeNameInputRef.current;
+    if (!input) {
+      return;
+    }
+    input.focus();
+    input.select();
+  }, []);
+  return { attachNodeNameInput, focusNodeNameInput } as const;
+};
+
+const useBuilderProviderValue = (): BuilderContextValue => {
+  const { nodes, setNodes, renameNode } = useNodesState();
+  const { selectedId, selectNode } = useSelectionState();
+  const { attachNodeNameInput, focusNodeNameInput } = useNodeNameInputHandle();
+  const addNode = useCallback((type: BuilderNodeType) => {
+    const index = nodes.filter((node) => node.type === type).length + 1;
+    const node: BuilderNode = {
+      id: crypto.randomUUID(),
+      type,
+      name: buildNodeName(type, index),
+    };
+    setNodes((current) => [...current, node]);
+    selectNode(node.id);
+    return node;
+  }, [nodes, selectNode, setNodes]);
+  return useMemo(
+    () => ({
+      nodes,
+      selectedId,
+      addNode,
+      renameNode,
+      selectNode,
+      attachNodeNameInput,
+      focusNodeNameInput,
+    }),
+    [nodes, selectedId, addNode, renameNode, selectNode, attachNodeNameInput, focusNodeNameInput],
+  );
+};
+
+export const BuilderProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const value = useBuilderProviderValue();
+  return <BuilderContext.Provider value={value}>{children}</BuilderContext.Provider>;
+};
+
+export const useBuilder = (): BuilderContextValue => {
+  const context = useContext(BuilderContext);
+  if (!context) {
+    throw new Error("useBuilder must be used within a BuilderProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- add a builder context to manage node creation, selection, and input focus
- auto-focus the RightPane node name input when the selection changes
- introduce global keyboard shortcuts for adding text and button nodes while ignoring editable targets

## Testing
- not run (project setup not available)


------
https://chatgpt.com/codex/tasks/task_e_68de7f4765d8832c88bb4cd1fbf97028