### PR TITLE
Refactor builder mini UI to use editor store

### DIFF
--- a/apps/builder/app/builder-mini/_components/HeaderBar.tsx
+++ b/apps/builder/app/builder-mini/_components/HeaderBar.tsx
@@ -1,58 +1,94 @@
-"use client";
+'use client';
 
-import { useEffect } from "react";
-import { BuilderNodeType, useBuilder } from "./builderContext";
+import { useEffect } from 'react';
+import type { CSSProperties } from 'react';
+import { useEditorStore } from '../../../../../packages/core/store/editor.store';
+import { useBuilder } from './builderContext';
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '12px 16px',
+  borderBottom: '1px solid #e5e7eb',
+  backgroundColor: '#ffffff',
+};
+
+const titleStyle: CSSProperties = { fontWeight: 600 };
+
+const rightSectionStyle: CSSProperties = { display: 'flex', alignItems: 'center', gap: 12 };
+
+const statusStyle: CSSProperties = { fontSize: 14, display: 'flex', alignItems: 'center', gap: 6 };
+
+const buttonStyle: CSSProperties = {
+  padding: '8px 12px',
+  borderRadius: 6,
+  backgroundColor: '#2563eb',
+  color: '#ffffff',
+  border: 'none',
+  cursor: 'pointer',
+};
 
 const isEditableElement = (target: EventTarget | null): boolean => {
-  if (!target || !(target instanceof HTMLElement)) {
-    return false;
-  }
-  const tagName = target.tagName.toLowerCase();
-  if (target.isContentEditable) {
-    return true;
-  }
-  return tagName === "input" || tagName === "textarea" || tagName === "select";
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return target.isContentEditable || tag === 'input' || tag === 'textarea' || tag === 'select';
 };
 
-const toNodeType = (key: string): BuilderNodeType | null => {
-  if (key === "t") {
-    return "text";
-  }
-  if (key === "b") {
-    return "button";
-  }
-  return null;
-};
+export default function HeaderBar() {
+  const title = useEditorStore((s) => s.doc.title);
+  const saveNow = useEditorStore((s) => s.saveNow);
+  const isDirty = useEditorStore((s) => s.isDirty);
+  const dirty = isDirty();
 
-const useGlobalNodeShortcuts = () => {
   const { addNode, focusNodeNameInput } = useBuilder();
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
-        return;
-      }
-      if (isEditableElement(event.target)) {
-        return;
-      }
-      const nodeType = toNodeType(event.key.toLowerCase());
-      if (!nodeType) {
-        return;
-      }
-      addNode(nodeType);
-      focusNodeNameInput();
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [addNode, focusNodeNameInput]);
-};
 
-export const HeaderBar: React.FC = () => {
-  useGlobalNodeShortcuts();
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+
+      // Save: Cmd/Ctrl+S
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        saveNow();
+        window.alert('Saved');
+        return;
+      }
+
+      // Node shortcuts disabled inside editable controls
+      if (isEditableElement(e.target)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      // Add Text (t), Button (b)
+      const k = e.key.toLowerCase();
+      if (k === 't') {
+        addNode('text');
+        // 追加直後に名前入力へ
+        setTimeout(focusNodeNameInput, 0);
+      } else if (k === 'b') {
+        addNode('button');
+        setTimeout(focusNodeNameInput, 0);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [saveNow, addNode, focusNodeNameInput]);
+
+  const statusColor = dirty ? '#dc2626' : '#10b981';
+  const statusLabel = dirty ? '● 未保存' : '✓ 保存済み';
+
   return (
-    <header className="header-bar">
-      <h1>Builder Mini</h1>
+    <header style={headerStyle}>
+      <div style={titleStyle}>
+        <strong>{title}</strong>
+      </div>
+      <div style={rightSectionStyle}>
+        <span style={{ ...statusStyle, color: statusColor }}>{statusLabel}</span>
+        <button type="button" style={buttonStyle} onClick={() => (saveNow(), window.alert('Saved'))}>
+          保存
+        </button>
+      </div>
     </header>
   );
-};
+}

--- a/apps/builder/app/builder-mini/_components/builderContext.tsx
+++ b/apps/builder/app/builder-mini/_components/builderContext.tsx
@@ -1,102 +1,58 @@
-"use client";
+'use client';
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useMemo, useRef, type PropsWithChildren } from 'react';
+import { useEditorStore } from '../../../../../packages/core/store/editor.store';
 
-export type BuilderNodeType = "text" | "button";
+/**
+ * Builder UI helpers only:
+ * - addNode: データ操作はZustandに委譲（単一の真実のソース）
+ * - attach/focus: 右ペインの入力フォーカス制御（UI専用）
+ */
+type NodeKind = 'text' | 'button';
 
-export interface BuilderNode {
-  readonly id: string;
-  readonly type: BuilderNodeType;
-  readonly name: string;
-}
-
-interface BuilderContextValue {
-  readonly nodes: ReadonlyArray<BuilderNode>;
-  readonly selectedId: string | null;
-  readonly addNode: (type: BuilderNodeType) => BuilderNode;
-  readonly renameNode: (id: string, name: string) => void;
-  readonly selectNode: (id: string | null) => void;
-  readonly attachNodeNameInput: (input: HTMLInputElement | null) => void;
-  readonly focusNodeNameInput: () => void;
-}
+type BuilderContextValue = {
+  addNode: (kind: NodeKind) => void;
+  attachNodeNameInput: (input: HTMLInputElement | null) => void;
+  focusNodeNameInput: () => void;
+};
 
 const BuilderContext = createContext<BuilderContextValue | null>(null);
 
-const buildNodeName = (type: BuilderNodeType, index: number) => {
-  const label = type === "text" ? "Text" : "Button";
-  return `${label} ${index}`;
-};
-
-const useNodesState = () => {
-  const [nodes, setNodes] = useState<ReadonlyArray<BuilderNode>>([]);
-  const renameNode = useCallback((id: string, name: string) => {
-    setNodes((current) => current.map((node) => (node.id === id ? { ...node, name } : node)));
-  }, []);
-  return { nodes, setNodes, renameNode } as const;
-};
-
-const useSelectionState = () => {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const selectNode = useCallback((id: string | null) => {
-    setSelectedId(id);
-  }, []);
-  return { selectedId, selectNode } as const;
-};
-
-const useNodeNameInputHandle = () => {
+export function BuilderProvider({ children }: PropsWithChildren) {
+  const addNodeStore = useEditorStore((s) => s.addNode);
   const nodeNameInputRef = useRef<HTMLInputElement | null>(null);
-  const attachNodeNameInput = useCallback((input: HTMLInputElement | null) => {
-    nodeNameInputRef.current = input;
+
+  const attachNodeNameInput = useCallback((el: HTMLInputElement | null) => {
+    nodeNameInputRef.current = el;
   }, []);
+
   const focusNodeNameInput = useCallback(() => {
-    const input = nodeNameInputRef.current;
-    if (!input) {
-      return;
-    }
-    input.focus();
-    input.select();
+    const el = nodeNameInputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
   }, []);
-  return { attachNodeNameInput, focusNodeNameInput } as const;
-};
 
-const useBuilderProviderValue = (): BuilderContextValue => {
-  const { nodes, setNodes, renameNode } = useNodesState();
-  const { selectedId, selectNode } = useSelectionState();
-  const { attachNodeNameInput, focusNodeNameInput } = useNodeNameInputHandle();
-  const addNode = useCallback((type: BuilderNodeType) => {
-    const index = nodes.filter((node) => node.type === type).length + 1;
-    const node: BuilderNode = {
-      id: crypto.randomUUID(),
-      type,
-      name: buildNodeName(type, index),
-    };
-    setNodes((current) => [...current, node]);
-    selectNode(node.id);
-    return node;
-  }, [nodes, selectNode, setNodes]);
-  return useMemo(
-    () => ({
-      nodes,
-      selectedId,
-      addNode,
-      renameNode,
-      selectNode,
-      attachNodeNameInput,
-      focusNodeNameInput,
-    }),
-    [nodes, selectedId, addNode, renameNode, selectNode, attachNodeNameInput, focusNodeNameInput],
+  const addNode = useCallback(
+    (kind: NodeKind) => {
+      // Zustand側で追加＆選択まで実施済み（前工程で実装ずみ）
+      addNodeStore(kind);
+    },
+    [addNodeStore]
   );
-};
 
-export const BuilderProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const value = useBuilderProviderValue();
+  const value = useMemo(
+    () => ({ addNode, attachNodeNameInput, focusNodeNameInput }),
+    [addNode, attachNodeNameInput, focusNodeNameInput]
+  );
+
   return <BuilderContext.Provider value={value}>{children}</BuilderContext.Provider>;
-};
+}
 
-export const useBuilder = (): BuilderContextValue => {
-  const context = useContext(BuilderContext);
-  if (!context) {
-    throw new Error("useBuilder must be used within a BuilderProvider");
+export function useBuilder() {
+  const ctx = useContext(BuilderContext);
+  if (!ctx) {
+    throw new Error('useBuilder must be used within <BuilderProvider>');
   }
-  return context;
-};
+  return ctx;
+}

--- a/apps/builder/app/builder-mini/page.tsx
+++ b/apps/builder/app/builder-mini/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import HeaderBar from './_components/HeaderBar';
+import RightPane from './_components/RightPane';
+import { BuilderProvider } from './_components/builderContext';
+
+type PaneProps = { title: string };
+
+const containerStyle: CSSProperties = {
+  minHeight: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: '#f9fafb',
+};
+
+const panesStyle: CSSProperties = {
+  flex: 1,
+  display: 'grid',
+  gridTemplateColumns: '320px 1fr 320px',
+  gap: 16,
+  padding: 16,
+};
+
+const paneStyle: CSSProperties = {
+  padding: 16,
+  borderRadius: 12,
+  backgroundColor: '#ffffff',
+  border: '1px solid #e5e7eb',
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  marginBottom: 8,
+  fontSize: 16,
+  fontWeight: 600,
+};
+
+function PlaceholderPane({ title }: PaneProps) {
+  return (
+    <section style={paneStyle}>
+      <h2 style={titleStyle}>{title}</h2>
+      <p style={{ margin: 0, color: '#6b7280' }}>コンテンツ未実装</p>
+    </section>
+  );
+}
+
+const BuilderMiniPage = () => {
+  return (
+    <BuilderProvider>
+      <div style={containerStyle}>
+        <HeaderBar />
+        <main style={panesStyle}>
+          <PlaceholderPane title="左ペイン" />
+          <PlaceholderPane title="キャンバス" />
+          <section style={paneStyle}>
+            <h2 style={titleStyle}>詳細</h2>
+            <RightPane />
+          </section>
+        </main>
+      </div>
+    </BuilderProvider>
+  );
+};
+
+export default BuilderMiniPage;


### PR DESCRIPTION
## Summary
- adapt the builder context to delegate node operations to the shared editor store while keeping focus helpers
- refresh the header bar with save status UI and integrate keyboard shortcuts using the central store
- update the right pane to read and update selected node details via the store while keeping focus control in context
- wrap the builder mini page in the builder provider and scaffold placeholder panes for layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de8367b690832c8b4b3b6bf4420e11