### PR TITLE
Add builder mini editor store and panes

### DIFF
--- a/apps/builder/app/builder-mini/_components/Canvas.tsx
+++ b/apps/builder/app/builder-mini/_components/Canvas.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import type { CSSProperties, KeyboardEvent } from 'react';
+
+import { useEditorStore } from '../../../../../packages/core/store/editor.store';
+import type { EditorNode } from '../../../../../packages/core/store/editor.store';
+
+const canvasStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  padding: 24,
+  borderRadius: 16,
+  border: '1px dashed #d1d5db',
+  backgroundColor: '#f9fafb',
+  minHeight: '100%',
+  boxSizing: 'border-box',
+};
+
+const emptyStateStyle: CSSProperties = {
+  textAlign: 'center',
+  color: '#9ca3af',
+  fontSize: 14,
+};
+
+function getNodeContainerStyle(active: boolean): CSSProperties {
+  return {
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: active ? '#dbeafe' : '#ffffff',
+    border: active ? '1px solid #2563eb' : '1px solid transparent',
+    cursor: 'pointer',
+  };
+}
+
+const textStyle: CSSProperties = {
+  fontSize: 16,
+  color: '#111827',
+};
+
+const buttonStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '10px 16px',
+  borderRadius: 8,
+  border: 'none',
+  backgroundColor: '#2563eb',
+  color: '#ffffff',
+  fontSize: 14,
+};
+
+function CanvasNode({ node, active, onSelect }: { node: EditorNode; active: boolean; onSelect: () => void }) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect();
+    }
+  };
+
+  if (node.kind === 'text') {
+    return (
+      <div
+        style={getNodeContainerStyle(active)}
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={handleKeyDown}
+      >
+        <p style={textStyle}>{node.name}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={getNodeContainerStyle(active)}
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={handleKeyDown}
+    >
+      <button type="button" style={buttonStyle}>
+        {node.name}
+      </button>
+    </div>
+  );
+}
+
+export default function Canvas() {
+  const nodes = useEditorStore((s) => s.doc.nodes);
+  const selectedId = useEditorStore((s) => s.selectedId);
+  const selectNode = useEditorStore((s) => s.selectNode);
+
+  if (nodes.length === 0) {
+    return (
+      <div style={canvasStyle}>
+        <p style={emptyStateStyle}>左のペインからノードを追加してください</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={canvasStyle}>
+      {nodes.map((node) => (
+        <CanvasNode key={node.id} node={node} active={node.id === selectedId} onSelect={() => selectNode(node.id)} />
+      ))}
+    </div>
+  );
+}

--- a/apps/builder/app/builder-mini/_components/LeftPane.tsx
+++ b/apps/builder/app/builder-mini/_components/LeftPane.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { useCallback } from 'react';
+
+import { useEditorStore } from '../../../../../packages/core/store/editor.store';
+import type { NodeKind } from '../../../../../packages/core/store/editor.store';
+import { useBuilder } from './builderContext';
+
+const containerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+};
+
+const sectionTitleStyle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+  color: '#6b7280',
+};
+
+const addRowStyle: CSSProperties = {
+  display: 'flex',
+  gap: 8,
+};
+
+const addButtonStyle: CSSProperties = {
+  flex: 1,
+  padding: '8px 12px',
+  borderRadius: 6,
+  border: '1px solid #e5e7eb',
+  backgroundColor: '#f9fafb',
+  cursor: 'pointer',
+  fontSize: 13,
+};
+
+const listStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+};
+
+const emptyStateStyle: CSSProperties = {
+  fontSize: 13,
+  color: '#9ca3af',
+};
+
+const kindBadgeBase: CSSProperties = {
+  fontSize: 12,
+  padding: '2px 6px',
+  borderRadius: 999,
+  backgroundColor: '#e5e7eb',
+  color: '#374151',
+};
+
+function getNodeButtonStyle(active: boolean): CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    padding: '10px 12px',
+    borderRadius: 8,
+    border: active ? '1px solid #2563eb' : '1px solid #e5e7eb',
+    backgroundColor: active ? '#eff6ff' : '#ffffff',
+    cursor: 'pointer',
+    fontSize: 14,
+    fontWeight: active ? 600 : 500,
+    color: '#111827',
+  };
+}
+
+function getKindBadgeStyle(kind: NodeKind): CSSProperties {
+  return {
+    ...kindBadgeBase,
+    backgroundColor: kind === 'text' ? '#ede9fe' : '#d1fae5',
+    color: kind === 'text' ? '#5b21b6' : '#047857',
+  };
+}
+
+function kindLabel(kind: NodeKind): string {
+  return kind === 'text' ? 'テキスト' : 'ボタン';
+}
+
+export default function LeftPane() {
+  const nodes = useEditorStore((s) => s.doc.nodes);
+  const selectedId = useEditorStore((s) => s.selectedId);
+  const selectNode = useEditorStore((s) => s.selectNode);
+
+  const { addNode, focusNodeNameInput } = useBuilder();
+
+  const handleAdd = useCallback(
+    (kind: NodeKind) => {
+      addNode(kind);
+      setTimeout(focusNodeNameInput, 0);
+    },
+    [addNode, focusNodeNameInput]
+  );
+
+  return (
+    <div style={containerStyle}>
+      <section>
+        <p style={sectionTitleStyle}>ノードを追加</p>
+        <div style={addRowStyle}>
+          <button type="button" style={addButtonStyle} onClick={() => handleAdd('text')}>
+            テキスト
+          </button>
+          <button type="button" style={addButtonStyle} onClick={() => handleAdd('button')}>
+            ボタン
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <p style={sectionTitleStyle}>ノード一覧</p>
+        <div style={listStyle}>
+          {nodes.length === 0 ? (
+            <p style={emptyStateStyle}>まだノードがありません</p>
+          ) : (
+            nodes.map((node) => {
+              const active = node.id === selectedId;
+              return (
+                <button
+                  key={node.id}
+                  type="button"
+                  style={getNodeButtonStyle(active)}
+                  onClick={() => selectNode(node.id)}
+                >
+                  <span>{node.name}</span>
+                  <span style={getKindBadgeStyle(node.kind)}>{kindLabel(node.kind)}</span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/builder/app/builder-mini/_components/builderContext.tsx
+++ b/apps/builder/app/builder-mini/_components/builderContext.tsx
@@ -2,14 +2,13 @@
 
 import { createContext, useCallback, useContext, useMemo, useRef, type PropsWithChildren } from 'react';
 import { useEditorStore } from '../../../../../packages/core/store/editor.store';
+import type { NodeKind } from '../../../../../packages/core/store/editor.store';
 
 /**
  * Builder UI helpers only:
  * - addNode: データ操作はZustandに委譲（単一の真実のソース）
  * - attach/focus: 右ペインの入力フォーカス制御（UI専用）
  */
-type NodeKind = 'text' | 'button';
-
 type BuilderContextValue = {
   addNode: (kind: NodeKind) => void;
   attachNodeNameInput: (input: HTMLInputElement | null) => void;

--- a/packages/core/store/editor.store.ts
+++ b/packages/core/store/editor.store.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { create } from 'zustand';
+
+export type NodeKind = 'text' | 'button';
+
+export type EditorNode = {
+  id: string;
+  name: string;
+  kind: NodeKind;
+};
+
+export type EditorDocument = {
+  title: string;
+  nodes: EditorNode[];
+};
+
+type EditorState = {
+  doc: EditorDocument;
+  selectedId: string | null;
+  dirty: boolean;
+  addNode: (kind: NodeKind) => void;
+  selectNode: (id: string | null) => void;
+  updateNodeName: (id: string, name: string) => void;
+  saveNow: () => void;
+  isDirty: () => boolean;
+};
+
+const createIsDirty = (dirty: boolean) => () => dirty;
+
+const initialNodes: EditorNode[] = [
+  { id: 'node-1', name: 'ヒーロー見出し', kind: 'text' },
+  { id: 'node-2', name: 'Primary Button', kind: 'button' },
+];
+
+let nodeCounter = initialNodes.length;
+
+const initialDoc: EditorDocument = {
+  title: 'サンプルページ',
+  nodes: initialNodes,
+};
+
+export const useEditorStore = create<EditorState>((set, get) => ({
+  doc: initialDoc,
+  selectedId: null,
+  dirty: false,
+  addNode: (kind) => {
+    set((state) => {
+      const id = generateNodeId();
+      const name = createDefaultNodeName(kind, state.doc.nodes.length + 1);
+      return {
+        doc: { ...state.doc, nodes: [...state.doc.nodes, { id, name, kind }] },
+        selectedId: id,
+        dirty: true,
+        isDirty: createIsDirty(true),
+      };
+    });
+  },
+  selectNode: (id) =>
+    set((state) => {
+      if (id === null) return { selectedId: null };
+      const exists = state.doc.nodes.some((node) => node.id === id);
+      return exists ? { selectedId: id } : state;
+    }),
+  updateNodeName: (id, name) =>
+    set((state) => {
+      const index = state.doc.nodes.findIndex((node) => node.id === id);
+      if (index === -1) return state;
+
+      const target = state.doc.nodes[index];
+      if (target.name === name) return state;
+
+      const nextNodes = [...state.doc.nodes];
+      nextNodes[index] = { ...target, name };
+
+      return {
+        doc: { ...state.doc, nodes: nextNodes },
+        dirty: true,
+        isDirty: createIsDirty(true),
+      };
+    }),
+  saveNow: () => {
+    if (!get().dirty) return;
+    set({ dirty: false, isDirty: createIsDirty(false) });
+  },
+  isDirty: createIsDirty(false),
+}));
+
+function generateNodeId() {
+  nodeCounter += 1;
+  return `node-${nodeCounter}`;
+}
+
+function createDefaultNodeName(kind: NodeKind, index: number) {
+  const base = kind === 'text' ? 'テキスト' : 'ボタン';
+  return `${base} ${index}`;
+}


### PR DESCRIPTION
## Summary
- add a Zustand-powered editor store to back the builder mini UI
- implement LeftPane and Canvas components that interact with the shared store
- reuse the store's node kind type inside the builder context helpers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de858313b8832ca50f9bba5fb39081