### PR TITLE
Refactor editor store with persistence

### DIFF
--- a/apps/builder/app/builder-mini/_components/HeaderBar.tsx
+++ b/apps/builder/app/builder-mini/_components/HeaderBar.tsx
@@ -15,11 +15,8 @@ const headerStyle: CSSProperties = {
 };
 
 const titleStyle: CSSProperties = { fontWeight: 600 };
-
 const rightSectionStyle: CSSProperties = { display: 'flex', alignItems: 'center', gap: 12 };
-
 const statusStyle: CSSProperties = { fontSize: 14, display: 'flex', alignItems: 'center', gap: 6 };
-
 const buttonStyle: CSSProperties = {
   padding: '8px 12px',
   borderRadius: 6,
@@ -55,15 +52,13 @@ export default function HeaderBar() {
         return;
       }
 
-      // Node shortcuts disabled inside editable controls
+      // Node shortcuts（テキスト入力中は無効）
       if (isEditableElement(e.target)) return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
-      // Add Text (t), Button (b)
       const k = e.key.toLowerCase();
       if (k === 't') {
         addNode('text');
-        // 追加直後に名前入力へ
         setTimeout(focusNodeNameInput, 0);
       } else if (k === 'b') {
         addNode('button');

--- a/apps/builder/app/builder-mini/_components/RightPane.tsx
+++ b/apps/builder/app/builder-mini/_components/RightPane.tsx
@@ -6,30 +6,25 @@ import { useEditorStore } from '../../../../../packages/core/store/editor.store'
 import { useBuilder } from './builderContext';
 
 const paneStyle: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 12 };
-
 const placeholderStyle: CSSProperties = { color: '#9ca3af', fontSize: 14, margin: 0 };
-
 const labelStyle: CSSProperties = {
   fontSize: 12,
   fontWeight: 600,
   letterSpacing: '0.04em',
   textTransform: 'uppercase',
 };
-
 const inputStyle: CSSProperties = {
   padding: '8px 12px',
   borderRadius: 6,
   border: '1px solid #d1d5db',
   fontSize: 14,
 };
-
 const metaStyle: CSSProperties = { fontSize: 12, color: '#6b7280', margin: 0 };
 
 export default function RightPane() {
   const selectedId = useEditorStore((s) => s.selectedId);
   const doc = useEditorStore((s) => s.doc);
   const updateNodeName = useEditorStore((s) => s.updateNodeName);
-
   const { attachNodeNameInput, focusNodeNameInput } = useBuilder();
 
   const inputRef = useRef<HTMLInputElement>(null);

--- a/apps/builder/app/builder-mini/_components/builderContext.tsx
+++ b/apps/builder/app/builder-mini/_components/builderContext.tsx
@@ -5,9 +5,7 @@ import { useEditorStore } from '../../../../../packages/core/store/editor.store'
 import type { NodeKind } from '../../../../../packages/core/store/editor.store';
 
 /**
- * Builder UI helpers only:
- * - addNode: データ操作はZustandに委譲（単一の真実のソース）
- * - attach/focus: 右ペインの入力フォーカス制御（UI専用）
+ * Builder の UI ヘルパーだけを提供（データはZustandに一元化）
  */
 type BuilderContextValue = {
   addNode: (kind: NodeKind) => void;
@@ -34,8 +32,7 @@ export function BuilderProvider({ children }: PropsWithChildren) {
 
   const addNode = useCallback(
     (kind: NodeKind) => {
-      // Zustand側で追加＆選択まで実施済み（前工程で実装ずみ）
-      addNodeStore(kind);
+      addNodeStore(kind); // 追加→選択はstore側で実施
     },
     [addNodeStore]
   );
@@ -50,8 +47,6 @@ export function BuilderProvider({ children }: PropsWithChildren) {
 
 export function useBuilder() {
   const ctx = useContext(BuilderContext);
-  if (!ctx) {
-    throw new Error('useBuilder must be used within <BuilderProvider>');
-  }
+  if (!ctx) throw new Error('useBuilder must be used within <BuilderProvider>');
   return ctx;
 }


### PR DESCRIPTION
## Summary
- replace the editor store with a document-backed implementation that persists to localStorage and exposes serialization helpers
- expose NodeKind/EditorNode aliases and select/selectNode compatibility for existing UI components
- align builder helper components with the new store contract and tidy UI comments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8939095c832ca35fa61336b8cc2f