### PR TITLE
Fix autosave reactivity and streamline builder context

### DIFF
--- a/apps/builder/app/builder-mini/_components/AutoSaveEffect.tsx
+++ b/apps/builder/app/builder-mini/_components/AutoSaveEffect.tsx
@@ -4,10 +4,15 @@ import { useEffect, useRef } from 'react';
 import { useEditorStore } from '../../../../../packages/core/store/editor.store';
 
 export default function AutoSaveEffect() {
-  const [isDirty, saveNow] = useEditorStore((s) => [s.isDirty, s.saveNow]);
+  const [doc, lastSaved, computeSerialized, saveNow] = useEditorStore((s) => [
+    s.doc,
+    s.lastSaved,
+    s.computeSerialized,
+    s.saveNow,
+  ]);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const dirty = isDirty();
+  const dirty = computeSerialized() !== lastSaved;
 
   useEffect(() => {
     if (!dirty) {
@@ -18,12 +23,8 @@ export default function AutoSaveEffect() {
       return;
     }
 
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-
     timeoutRef.current = setTimeout(() => {
-      if (isDirty()) {
+      if (computeSerialized() !== lastSaved) {
         saveNow();
       }
     }, 800);
@@ -34,7 +35,7 @@ export default function AutoSaveEffect() {
         timeoutRef.current = null;
       }
     };
-  }, [dirty, isDirty, saveNow]);
+  }, [dirty, computeSerialized, lastSaved, saveNow, doc]);
 
   useEffect(() => {
     return () => {

--- a/apps/builder/app/builder-mini/_components/builderContext.tsx
+++ b/apps/builder/app/builder-mini/_components/builderContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useCallback, useContext, useMemo, useRef, type PropsWithChildren } from 'react';
 
-import { useEditorStore, type EditorStoreState, type NodeKind } from '../../../../../packages/core/store/editor.store';
+import { useEditorStore, type NodeKind } from '../../../../../packages/core/store/editor.store';
 
 type BuilderContextValue = {
   addNode: (kind: NodeKind) => void;
@@ -13,28 +13,23 @@ type BuilderContextValue = {
 const BuilderContext = createContext<BuilderContextValue | null>(null);
 
 export function BuilderProvider({ children }: PropsWithChildren) {
-  const addNodeStore = useEditorStore((state: EditorStoreState) => state.addNode);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const addNodeStore = useEditorStore((s) => s.addNode);
+  const nodeNameInputRef = useRef<HTMLInputElement | null>(null);
 
-  const attachNodeNameInput = useCallback((element: HTMLInputElement | null) => {
-    inputRef.current = element;
+  const attachNodeNameInput = useCallback((el: HTMLInputElement | null) => {
+    nodeNameInputRef.current = el;
   }, []);
 
   const focusNodeNameInput = useCallback(() => {
-    const element = inputRef.current;
-    if (!element) {
-      return;
-    }
-    element.focus();
-    element.select();
+    const el = nodeNameInputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
   }, []);
 
-  const addNode = useCallback(
-    (kind: NodeKind) => {
-      addNodeStore(kind); // Store selects the node immediately after creation.
-    },
-    [addNodeStore],
-  );
+  const addNode = useCallback((kind: NodeKind) => {
+    addNodeStore(kind);
+  }, [addNodeStore]);
 
   const value = useMemo(
     () => ({ addNode, attachNodeNameInput, focusNodeNameInput }),
@@ -45,9 +40,7 @@ export function BuilderProvider({ children }: PropsWithChildren) {
 }
 
 export function useBuilder() {
-  const context = useContext(BuilderContext);
-  if (!context) {
-    throw new Error('useBuilder must be used within <BuilderProvider>');
-  }
-  return context;
+  const v = useContext(BuilderContext);
+  if (!v) throw new Error('useBuilder must be used within <BuilderProvider>');
+  return v;
 }


### PR DESCRIPTION
## Summary
- ensure the autosave effect subscribes to doc and lastSaved so dirty state updates when content changes
- simplify the builder context to a single provider/useBuilder pair without duplicate definitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d3d38b24832cbfdd12df5643c5ae