### PR TITLE
Add resizing support for text and button nodes

### DIFF
--- a/apps/builder/app/builder-mini/_components/Canvas.tsx
+++ b/apps/builder/app/builder-mini/_components/Canvas.tsx
@@ -1,12 +1,14 @@
-﻿'use client';
+'use client';
 
-import { useState } from 'react';
-import type { CSSProperties, KeyboardEvent } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import type {
+  CSSProperties,
+  DragEvent as ReactDragEvent,
+  KeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+} from 'react';
 
-import {
-  useEditorStore,
-  type EditorNode,
-} from '../../../../../packages/core/store/editor.store';
+import { useEditorStore, type EditorNode } from '../../../../../packages/core/store/editor.store';
 
 const canvasStyle: CSSProperties = {
   display: 'flex',
@@ -22,7 +24,12 @@ const canvasStyle: CSSProperties = {
 
 const emptyStateStyle: CSSProperties = { textAlign: 'center', color: '#9ca3af', fontSize: 14 };
 
-function getNodeContainerStyle(active: boolean, showTop: boolean, showBottom: boolean, dragging: boolean): CSSProperties {
+function getNodeContainerStyle(
+  active: boolean,
+  showTop: boolean,
+  showBottom: boolean,
+  dragging: boolean,
+): CSSProperties {
   return {
     padding: 12,
     borderRadius: 12,
@@ -30,6 +37,7 @@ function getNodeContainerStyle(active: boolean, showTop: boolean, showBottom: bo
     border: active ? '1px solid #2563eb' : '1px solid transparent',
     cursor: 'grab',
     opacity: dragging ? 0.5 : 1,
+    position: 'relative',
     boxShadow: showTop
       ? 'inset 0 2px 0 0 #2563eb'
       : showBottom
@@ -52,6 +60,18 @@ const buttonStyle: CSSProperties = {
   fontSize: 14,
 };
 
+const resizeHandleStyle: CSSProperties = {
+  position: 'absolute',
+  right: 4,
+  bottom: 4,
+  width: 12,
+  height: 12,
+  borderRadius: 2,
+  border: '1px solid #2563eb',
+  background: '#eff6ff',
+  cursor: 'nwse-resize',
+};
+
 function CanvasNode({
   node,
   active,
@@ -66,20 +86,71 @@ function CanvasNode({
   onSelect: () => void;
   draggableProps: {
     draggable: true;
-    onDragStart: (e: React.DragEvent) => void;
+    onDragStart: (e: ReactDragEvent) => void;
     onDragEnd: () => void;
-    onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+    onDragOver: (e: ReactDragEvent<HTMLDivElement>) => void;
     onDragLeave: () => void;
   };
   showTop: boolean;
   showBottom: boolean;
   dragging: boolean;
 }) {
+  const updateNodeProps = useEditorStore((s) => s.updateNodeProps);
+  const [live, setLive] = useState<{ w: number; h: number } | null>(null);
+  const startRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
+  const liveRef = useRef<{ w: number; h: number } | null>(null);
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       onSelect();
     }
+  };
+
+  const startResize = useCallback(
+    (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const w = (node.props as any)?.width ?? 240;
+      const h = (node.props as any)?.height ?? 80;
+      startRef.current = { x: e.clientX, y: e.clientY, w, h };
+      liveRef.current = { w, h };
+      setLive({ w, h });
+
+      const onMove = (ev: MouseEvent) => {
+        if (!startRef.current) return;
+        const dx = ev.clientX - startRef.current.x;
+        const dy = ev.clientY - startRef.current.y;
+        const nextW = Math.max(40, Math.round(startRef.current.w + dx));
+        const nextH = Math.max(32, Math.round(startRef.current.h + dy));
+        const next = { w: nextW, h: nextH };
+        liveRef.current = next;
+        setLive(next);
+      };
+
+      const onUp = () => {
+        const finalSize = liveRef.current;
+        if (startRef.current && finalSize) {
+          updateNodeProps(node.id, { width: finalSize.w, height: finalSize.h } as any);
+        }
+        startRef.current = null;
+        liveRef.current = null;
+        setLive(null);
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [node.id, node.props, updateNodeProps],
+  );
+
+  const w = live?.w ?? (node.props as any)?.width ?? undefined;
+  const h = live?.h ?? (node.props as any)?.height ?? undefined;
+  const sizedStyle: CSSProperties = {
+    ...(w !== undefined ? { width: w } : {}),
+    ...(h !== undefined ? { height: h } : {}),
   };
 
   if (node.kind === 'text') {
@@ -89,7 +160,7 @@ function CanvasNode({
 
     return (
       <div
-        style={getNodeContainerStyle(active, showTop, showBottom, dragging)}
+        style={{ ...getNodeContainerStyle(active, showTop, showBottom, dragging), ...sizedStyle }}
         role="button"
         tabIndex={0}
         onClick={onSelect}
@@ -97,13 +168,14 @@ function CanvasNode({
         {...draggableProps}
       >
         <p style={{ ...textStyle, fontSize }}>{displayText}</p>
+        <div style={resizeHandleStyle} onMouseDown={startResize} />
       </div>
     );
   }
 
   return (
     <div
-      style={getNodeContainerStyle(active, showTop, showBottom, dragging)}
+      style={{ ...getNodeContainerStyle(active, showTop, showBottom, dragging), ...sizedStyle }}
       role="button"
       tabIndex={0}
       onClick={onSelect}
@@ -113,6 +185,7 @@ function CanvasNode({
       <button type="button" style={buttonStyle}>
         {node.props?.label ?? node.name}
       </button>
+      <div style={resizeHandleStyle} onMouseDown={startResize} />
     </div>
   );
 }
@@ -126,7 +199,7 @@ export default function Canvas() {
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropIndex, setDropIndex] = useState<number | null>(null);
 
-  const onDragStart = (id: string) => (e: React.DragEvent) => {
+  const onDragStart = (id: string) => (e: ReactDragEvent) => {
     e.dataTransfer.setData('text/plain', id);
     e.dataTransfer.effectAllowed = 'move';
     setDraggingId(id);
@@ -137,7 +210,7 @@ export default function Canvas() {
     setDropIndex(null);
   };
 
-  const onDragOverItem = (index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+  const onDragOverItem = (index: number) => (e: ReactDragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const rect = e.currentTarget.getBoundingClientRect();
     const before = e.clientY - rect.top < rect.height / 2;
@@ -146,14 +219,15 @@ export default function Canvas() {
   };
 
   const onDragLeaveItem = () => {
+    // no-op
   };
 
-  const onDragOverCanvas = (e: React.DragEvent) => {
+  const onDragOverCanvas = (e: ReactDragEvent) => {
     e.preventDefault();
     if (nodes.length > 0 && dropIndex == null) setDropIndex(nodes.length);
   };
 
-  const onDropCanvas = (e: React.DragEvent) => {
+  const onDropCanvas = (e: ReactDragEvent) => {
     e.preventDefault();
     const id = e.dataTransfer.getData('text/plain');
     if (!id || dropIndex == null) return;

--- a/apps/builder/app/builder-mini/_components/RightPane.tsx
+++ b/apps/builder/app/builder-mini/_components/RightPane.tsx
@@ -61,6 +61,18 @@ export default function RightPane() {
     updateNodeProps(selectedNode.id, { label: e.target.value });
   };
 
+  const handleWidthChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    if (Number.isNaN(value)) return;
+    updateNodeProps(selectedNode.id, { width: Math.max(40, value) } as any);
+  };
+
+  const handleHeightChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    if (Number.isNaN(value)) return;
+    updateNodeProps(selectedNode.id, { height: Math.max(32, value) } as any);
+  };
+
   return (
     <aside style={paneStyle}>
       <label style={labelStyle} htmlFor="node-name">ノード名</label>
@@ -74,6 +86,28 @@ export default function RightPane() {
       />
       <p style={metaStyle}>id: {selectedNode.id}</p>
       <p style={metaStyle}>kind: {selectedNode.kind}</p>
+
+      <label style={labelStyle} htmlFor="node-width">幅 (px)</label>
+      <input
+        id="node-width"
+        type="number"
+        min={40}
+        step={1}
+        value={(selectedNode.props as any).width ?? ''}
+        onChange={handleWidthChange}
+        style={inputStyle}
+      />
+
+      <label style={labelStyle} htmlFor="node-height">高さ (px)</label>
+      <input
+        id="node-height"
+        type="number"
+        min={32}
+        step={1}
+        value={(selectedNode.props as any).height ?? ''}
+        onChange={handleHeightChange}
+        style={inputStyle}
+      />
 
       {selectedNode.kind === 'text' ? (
         <>

--- a/packages/core/store/editor.store.ts
+++ b/packages/core/store/editor.store.ts
@@ -20,13 +20,13 @@ const createSampleDocument = (): Document => ({
       id: 'node-text-1',
       name: 'Hero Title',
       kind: 'text',
-      props: { text: 'Hello world', fontSize: 32 },
+      props: { text: 'Hello world', fontSize: 32, width: 480, height: 120 },
     },
     {
       id: 'node-button-1',
       name: 'Primary Action',
       kind: 'button',
-      props: { label: 'Click me' },
+      props: { label: 'Click me', width: 200, height: 48 },
     },
   ],
 });
@@ -77,9 +77,19 @@ const genId = (kind: NodeKind): string => {
 const createNodeForKind = (kind: NodeKind, id: string, index: number): Node => {
   switch (kind) {
     case 'text':
-      return { id, name: `Text ${index}`, kind, props: { text: 'New Text', fontSize: 16 } };
+      return {
+        id,
+        name: `Text ${index}`,
+        kind,
+        props: { text: 'New Text', fontSize: 16, width: 300, height: 80 },
+      };
     case 'button':
-      return { id, name: `Button ${index}`, kind, props: { label: 'New Button' } };
+      return {
+        id,
+        name: `Button ${index}`,
+        kind,
+        props: { label: 'New Button', width: 160, height: 40 },
+      };
     case 'header':
       return { id, name: `Header ${index}`, kind, props: { height: 64, background: '#ffffff' } };
     case 'footer':
@@ -117,7 +127,10 @@ type EditorState = {
 
   updateNodeProps: (
     id: string,
-    props: Partial<{ text: string; fontSize: number } | { label: string }>,
+    props: Partial<
+      | { text: string; fontSize: number; width: number; height: number }
+      | { label: string; width: number; height: number }
+    >,
   ) => void;
 
   deleteNode: (id: string) => void;
@@ -166,6 +179,14 @@ const editorStoreCreator: StateCreator<EditorState> = (set, get) => {
           nextProps.fontSize = props.fontSize;
           changed = true;
         }
+        if (props.width !== undefined && props.width !== nextProps.width) {
+          nextProps.width = props.width;
+          changed = true;
+        }
+        if (props.height !== undefined && props.height !== nextProps.height) {
+          nextProps.height = props.height;
+          changed = true;
+        }
         if (!changed) return;
 
         const nodes = doc.nodes.map((n) => (n.id === id ? { ...n, props: nextProps } : n));
@@ -179,6 +200,14 @@ const editorStoreCreator: StateCreator<EditorState> = (set, get) => {
 
         if (props.label !== undefined && props.label !== nextProps.label) {
           nextProps.label = props.label;
+          changed = true;
+        }
+        if (props.width !== undefined && props.width !== nextProps.width) {
+          nextProps.width = props.width;
+          changed = true;
+        }
+        if (props.height !== undefined && props.height !== nextProps.height) {
+          nextProps.height = props.height;
           changed = true;
         }
         if (!changed) return;


### PR DESCRIPTION
## Summary
- add width and height defaults plus persistence for text and button nodes in the editor store
- allow canvas nodes to preview resizing via a drag handle before committing changes
- expose width and height number inputs in the inspector pane for manual adjustment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f803a4c0832c88ddb89316b91709