### PR TITLE
Refine keyboard event typing in Canvas component

### DIFF
--- a/apps/builder/app/builder-mini/_components/Canvas.tsx
+++ b/apps/builder/app/builder-mini/_components/Canvas.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from 'react';
 import type {
   CSSProperties,
   DragEvent as ReactDragEvent,
-  KeyboardEvent,
+  KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
 } from 'react';
 
@@ -100,7 +100,7 @@ function CanvasNode({
   const startRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
   const liveRef = useRef<{ w: number; h: number } | null>(null);
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       onSelect();


### PR DESCRIPTION
## Summary
- alias React's keyboard event type to avoid conflicts with DOM globals
- update `handleKeyDown` to reference the renamed type

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68e0fc806650832c9795efffd99e1bf0