### PR TITLE
feat: support header/footer presets and button actions

### DIFF
--- a/apps/builder/app/builder-mini/_components/Canvas.tsx
+++ b/apps/builder/app/builder-mini/_components/Canvas.tsx
@@ -419,8 +419,20 @@ export default function Canvas() {
           const p: any = node.props ?? {};
           const x = p.x ?? 0;
           const y = p.y ?? 0;
-          const w = p.width ?? (node.kind === 'text' ? 300 : 160);
-          const h = p.height ?? (node.kind === 'text' ? 80 : 40);
+          const w =
+            p.width ??
+            (node.kind === 'text'
+              ? 300
+              : node.kind === 'header' || node.kind === 'footer'
+              ? 1200
+              : 160);
+          const h =
+            p.height ??
+            (node.kind === 'text'
+              ? 80
+              : node.kind === 'header' || node.kind === 'footer'
+              ? 64
+              : 40);
           const active = node.id === selectedId;
 
           return (
@@ -453,13 +465,39 @@ export default function Canvas() {
             >
               {node.kind === 'text' ? (
                 <div style={{ padding: 12, width: '100%', height: '100%', display: 'flex', alignItems: 'center' }}>
-                  <p style={{ ...textStyle, fontSize: (p.fontSize ?? 16) }}>{p.text ?? node.name}</p>
+                  <p style={{ ...textStyle, fontSize: p.fontSize ?? 16 }}>{p.text ?? node.name}</p>
                 </div>
-              ) : (
+              ) : node.kind === 'button' ? (
                 <div style={{ width: '100%', height: '100%', display: 'grid', placeItems: 'center' }}>
-                  <button type="button" style={buttonInner}>{p.label ?? node.name}</button>
+                  <button
+                    type="button"
+                    style={buttonInner}
+                    onDoubleClick={(e) => {
+                      e.stopPropagation();
+                      const a = (p as any).action;
+                      if (!a) return;
+                      if (a.type === 'alert' && a.message) window.alert(a.message);
+                      if (a.type === 'open_url' && a.url)
+                        window.open(a.url, '_blank', 'noopener,noreferrer');
+                    }}
+                  >
+                    {p.label ?? node.name}
+                  </button>
                 </div>
-              )}
+              ) : node.kind === 'header' || node.kind === 'footer' ? (
+                <div
+                  style={{
+                    width: '100%',
+                    height: '100%',
+                    background: p.background ?? '#ffffff',
+                    display: 'flex',
+                    alignItems: 'center',
+                    padding: 12,
+                  }}
+                >
+                  <span style={{ fontSize: 12, color: '#6b7280' }}>{node.kind.toUpperCase()}</span>
+                </div>
+              ) : null}
             </div>
           );
         })}

--- a/apps/builder/app/builder-mini/_components/LeftPane.tsx
+++ b/apps/builder/app/builder-mini/_components/LeftPane.tsx
@@ -47,15 +47,33 @@ const kindBadgeBase: CSSProperties = {
 };
 
 function getKindBadgeStyle(kind: NodeKind): CSSProperties {
-  return {
-    ...kindBadgeBase,
-    backgroundColor: kind === 'text' ? '#ede9fe' : '#d1fae5',
-    color: kind === 'text' ? '#5b21b6' : '#047857',
-  };
+  switch (kind) {
+    case 'text':
+      return { ...kindBadgeBase, backgroundColor: '#ede9fe', color: '#5b21b6' };
+    case 'button':
+      return { ...kindBadgeBase, backgroundColor: '#d1fae5', color: '#047857' };
+    case 'header':
+      return { ...kindBadgeBase, backgroundColor: '#fee2e2', color: '#b91c1c' };
+    case 'footer':
+      return { ...kindBadgeBase, backgroundColor: '#dbeafe', color: '#1d4ed8' };
+    default:
+      return kindBadgeBase;
+  }
 }
 
 function kindLabel(kind: NodeKind): string {
-  return kind === 'text' ? 'テキスト' : 'ボタン';
+  switch (kind) {
+    case 'text':
+      return 'テキスト';
+    case 'button':
+      return 'ボタン';
+    case 'header':
+      return 'ヘッダー';
+    case 'footer':
+      return 'フッター';
+    default:
+      return kind;
+  }
 }
 
 function getItemStyle(active: boolean, showTop: boolean, showBottom: boolean, dragging: boolean): CSSProperties {
@@ -186,6 +204,19 @@ export default function LeftPane() {
           </button>
         </div>
         <p style={helpStyle}>ドラッグ＆ドロップで並べ替えできます</p>
+      </section>
+
+      <section>
+        <p style={sectionTitleStyle}>プリセット</p>
+        <div style={addRowStyle}>
+          <button type="button" style={addButtonStyle} onClick={() => handleAdd('header')}>
+            ヘッダー
+          </button>
+          <button type="button" style={addButtonStyle} onClick={() => handleAdd('footer')}>
+            フッター
+          </button>
+        </div>
+        <p style={helpStyle}>ドラッグで移動、右下辺のホットゾーンでリサイズ</p>
       </section>
 
       <section onDragOver={onDragOverList} onDrop={onDropList}>

--- a/apps/builder/app/builder-mini/_components/RightPane.tsx
+++ b/apps/builder/app/builder-mini/_components/RightPane.tsx
@@ -82,6 +82,8 @@ export default function RightPane() {
     if (!Number.isNaN(v)) updateNodeProps(selectedNode.id, { y: v } as any);
   };
 
+  const nodeProps = selectedNode.props as any;
+
   return (
     <aside style={paneStyle}>
       <label style={labelStyle} htmlFor="node-name">ノード名</label>
@@ -101,7 +103,7 @@ export default function RightPane() {
         id="node-x"
         type="number"
         step={1}
-        value={(selectedNode.props as any).x ?? 0}
+        value={nodeProps.x ?? 0}
         onChange={handleXChange}
         style={inputStyle}
       />
@@ -111,7 +113,7 @@ export default function RightPane() {
         id="node-y"
         type="number"
         step={1}
-        value={(selectedNode.props as any).y ?? 0}
+        value={nodeProps.y ?? 0}
         onChange={handleYChange}
         style={inputStyle}
       />
@@ -122,7 +124,7 @@ export default function RightPane() {
         type="number"
         min={40}
         step={1}
-        value={(selectedNode.props as any).width ?? ''}
+        value={nodeProps.width ?? ''}
         onChange={handleWidthChange}
         style={inputStyle}
       />
@@ -133,10 +135,23 @@ export default function RightPane() {
         type="number"
         min={32}
         step={1}
-        value={(selectedNode.props as any).height ?? ''}
+        value={nodeProps.height ?? ''}
         onChange={handleHeightChange}
         style={inputStyle}
       />
+
+      {(selectedNode.kind === 'header' || selectedNode.kind === 'footer') && (
+        <>
+          <label style={labelStyle} htmlFor="node-bg">背景色</label>
+          <input
+            id="node-bg"
+            type="color"
+            value={nodeProps.background ?? '#ffffff'}
+            onChange={(e) => updateNodeProps(selectedNode.id, { background: e.target.value } as any)}
+            style={{ ...inputStyle, padding: 0, height: 36 }}
+          />
+        </>
+      )}
 
       {selectedNode.kind === 'text' ? (
         <>
@@ -144,7 +159,7 @@ export default function RightPane() {
           <input
             id="node-text"
             type="text"
-            value={selectedNode.props.text}
+            value={nodeProps.text}
             onChange={handleTextValueChange}
             style={inputStyle}
           />
@@ -155,7 +170,7 @@ export default function RightPane() {
             min={8}
             max={128}
             step={1}
-            value={selectedNode.props.fontSize}
+            value={nodeProps.fontSize}
             onChange={handleFontSizeChange}
             style={inputStyle}
           />
@@ -168,10 +183,76 @@ export default function RightPane() {
           <input
             id="node-label"
             type="text"
-            value={selectedNode.props.label}
+            value={nodeProps.label}
             onChange={handleButtonLabelChange}
             style={inputStyle}
           />
+
+          <label style={labelStyle}>アクション</label>
+          <select
+            style={inputStyle}
+            value={nodeProps.action?.type ?? 'none'}
+            onChange={(e) => {
+              const t = e.target.value;
+              if (t === 'none') updateNodeProps(selectedNode.id, { action: null } as any);
+              if (t === 'alert')
+                updateNodeProps(selectedNode.id, { action: { type: 'alert', message: 'Hello!' } } as any);
+              if (t === 'open_url')
+                updateNodeProps(selectedNode.id, { action: { type: 'open_url', url: 'https://example.com' } } as any);
+            }}
+          >
+            <option value="none">なし</option>
+            <option value="alert">アラートを表示</option>
+            <option value="open_url">URLを開く</option>
+          </select>
+
+          {nodeProps.action?.type === 'alert' && (
+            <>
+              <label style={labelStyle} htmlFor="alert-msg">メッセージ</label>
+              <input
+                id="alert-msg"
+                type="text"
+                style={inputStyle}
+                value={nodeProps.action?.message ?? ''}
+                onChange={(e) =>
+                  updateNodeProps(selectedNode.id, {
+                    action: { type: 'alert', message: e.target.value },
+                  } as any)
+                }
+              />
+            </>
+          )}
+
+          {nodeProps.action?.type === 'open_url' && (
+            <>
+              <label style={labelStyle} htmlFor="action-url">URL</label>
+              <input
+                id="action-url"
+                type="text"
+                style={inputStyle}
+                placeholder="https://..."
+                value={nodeProps.action?.url ?? ''}
+                onChange={(e) =>
+                  updateNodeProps(selectedNode.id, {
+                    action: { type: 'open_url', url: e.target.value },
+                  } as any)
+                }
+              />
+            </>
+          )}
+
+          <button
+            type="button"
+            style={{ ...inputStyle, cursor: 'pointer' }}
+            onClick={() => {
+              const a = nodeProps.action;
+              if (!a) return;
+              if (a.type === 'alert' && a.message) window.alert(a.message);
+              if (a.type === 'open_url' && a.url) window.open(a.url, '_blank', 'noopener,noreferrer');
+            }}
+          >
+            テスト実行
+          </button>
         </>
       ) : null}
     </aside>


### PR DESCRIPTION
## Summary
- initialize header/footer nodes with stage-aligned defaults and broaden prop updates for layout/background/action fields
- render header/footer blocks on the canvas and allow buttons to trigger their configured actions on double click
- add header/footer presets plus background and action editors in the side panes

## Testing
- pnpm typecheck *(fails: Invalid package manager specification in package.json (pnpm@9); expected a semver version)*

------
https://chatgpt.com/codex/tasks/task_e_68e1140b8a24832c99395eab7cc0b892